### PR TITLE
libelf: update to 0.180 + no more loadable modules

### DIFF
--- a/recipes/elfutils/all/conandata.yml
+++ b/recipes/elfutils/all/conandata.yml
@@ -1,12 +1,12 @@
 sources:
-  "0.173":
-    url: "https://sourceware.org/elfutils/ftp/0.173/elfutils-0.173.tar.bz2"
-    sha256: "b76d8c133f68dad46250f5c223482c8299d454a69430d9aa5c19123345a000ff"
+  "0.180":
+    url: "https://sourceware.org/elfutils/ftp/0.180/elfutils-0.180.tar.bz2"
+    sha256: "b827b6e35c59d188ba97d7cf148fa8dc6f5c68eb6c5981888dfdbb758c0b569d"
 patches:
-  "0.173":
+  "0.180":
     - base_path: "source_subfolder"
       patch_file: "patches/0001-add-STATIC-support-for-binaries.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/0002-remove-Werror.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/0003-provide-package-install-path-to-dlopen.patch"
+#    - base_path: "source_subfolder"
+#      patch_file: "patches/0003-provide-package-install-path-to-dlopen.patch"

--- a/recipes/elfutils/all/patches/0001-add-STATIC-support-for-binaries.patch
+++ b/recipes/elfutils/all/patches/0001-add-STATIC-support-for-binaries.patch
@@ -1,7 +1,7 @@
 --- configure.ac
 +++ configure.ac
-@@ -324,7 +324,7 @@
- AM_CONDITIONAL(USE_VALGRIND, test "$use_valgrind" = yes)
+@@ -382,7 +382,7 @@
+ AM_CONDITIONAL(INSTALL_ELFH, test "$install_elfh" = yes)
  
  AM_CONDITIONAL(BUILD_STATIC, [dnl
 -test "$use_gprof" = yes -o "$use_gcov" = yes])

--- a/recipes/elfutils/all/patches/0002-remove-Werror.patch
+++ b/recipes/elfutils/all/patches/0002-remove-Werror.patch
@@ -1,7 +1,7 @@
 --- config/eu.am
 +++ config/eu.am
 @@ -73,7 +73,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
- 	    -Wold-style-definition -Wstrict-prototypes \
+ 	    -Wold-style-definition -Wstrict-prototypes -Wtrampolines \
  	    $(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
  	    $(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
 -	    $(if $($(*F)_no_Werror),,-Werror) \
@@ -13,7 +13,7 @@ diff --git a/configure.ac b/configure.ac
 index 1cf6245..6f0aaf0 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -130,7 +130,7 @@ AS_IF([test "x$ac_cv_c99" != xyes],
+@@ -132,7 +132,7 @@ AS_IF([test "x$ac_cv_c99" != xyes],
  AC_CACHE_CHECK([whether gcc supports __attribute__((visibility()))],
  	ac_cv_visibility, [dnl
  save_CFLAGS="$CFLAGS"
@@ -22,7 +22,7 @@ index 1cf6245..6f0aaf0 100644
  AC_COMPILE_IFELSE([AC_LANG_SOURCE([dnl
  int __attribute__((visibility("hidden")))
  foo (int a)
-@@ -146,7 +146,7 @@ fi
+@@ -148,7 +148,7 @@ fi
  AC_CACHE_CHECK([whether gcc supports __attribute__((gcc_struct))],
  	ac_cv_gcc_struct, [dnl
  save_CFLAGS="$CFLAGS"
@@ -31,7 +31,7 @@ index 1cf6245..6f0aaf0 100644
  AC_COMPILE_IFELSE([AC_LANG_SOURCE([dnl
  struct test { int x; } __attribute__((gcc_struct));
  ])], ac_cv_gcc_struct=yes, ac_cv_gcc_struct=no)
-@@ -158,7 +158,7 @@ fi
+@@ -160,7 +160,7 @@ fi
  
  AC_CACHE_CHECK([whether gcc supports -fPIC], ac_cv_fpic, [dnl
  save_CFLAGS="$CFLAGS"
@@ -40,7 +40,7 @@ index 1cf6245..6f0aaf0 100644
  AC_COMPILE_IFELSE([AC_LANG_SOURCE()], ac_cv_fpic=yes, ac_cv_fpic=no)
  CFLAGS="$save_CFLAGS"
  ])
-@@ -171,7 +171,7 @@ AC_SUBST([fpic_CFLAGS])
+@@ -173,7 +173,7 @@ AC_SUBST([fpic_CFLAGS])
  
  AC_CACHE_CHECK([whether gcc supports -fPIE], ac_cv_fpie, [dnl
  save_CFLAGS="$CFLAGS"
@@ -49,16 +49,16 @@ index 1cf6245..6f0aaf0 100644
  AC_COMPILE_IFELSE([AC_LANG_SOURCE()], ac_cv_fpie=yes, ac_cv_fpie=no)
  CFLAGS="$save_CFLAGS"
  ])
-@@ -250,7 +250,7 @@ case "$CFLAGS" in
+@@ -273,7 +273,7 @@ case "$CFLAGS" in
      ;;
    *)
      save_CFLAGS="$CFLAGS"
--    CFLAGS="-D_FORTIFY_SOURCE=2 -Werror $CFLAGS"
-+    CFLAGS="-D_FORTIFY_SOURCE=2  $CFLAGS"
+-    CFLAGS="-D_FORTIFY_SOURCE=2 $CFLAGS -Werror"
++    CFLAGS="-D_FORTIFY_SOURCE=2 $CFLAGS"
      AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
        #include <string.h>
        int main() { return 0; }
-@@ -410,7 +410,7 @@ AS_IF([test "x$enable_symbol_versioning" = "xno"],
+@@ -459,7 +459,7 @@ AS_IF([test "x$enable_symbol_versioning" = "xno"],
  
  AC_CACHE_CHECK([whether gcc accepts -Wstack-usage], ac_cv_stack_usage, [dnl
  old_CFLAGS="$CFLAGS"
@@ -67,7 +67,7 @@ index 1cf6245..6f0aaf0 100644
  AC_COMPILE_IFELSE([AC_LANG_SOURCE([])],
  		  ac_cv_stack_usage=yes, ac_cv_stack_usage=no)
  CFLAGS="$old_CFLAGS"])
-@@ -419,7 +419,7 @@ AM_CONDITIONAL(ADD_STACK_USAGE_WARNING, [test "x$ac_cv_stack_usage" != "xno"])
+@@ -468,7 +468,7 @@ AM_CONDITIONAL(ADD_STACK_USAGE_WARNING, [test "x$ac_cv_stack_usage" != "xno"])
  # -Wlogical-op was too fragile in the past, make sure we get a sane one.
  AC_CACHE_CHECK([whether gcc has a sane -Wlogical-op], ac_cv_logical_op, [dnl
  old_CFLAGS="$CFLAGS"
@@ -76,7 +76,7 @@ index 1cf6245..6f0aaf0 100644
  AC_COMPILE_IFELSE([AC_LANG_SOURCE(
  	[#define FLAG 1
  	int f (int r, int f) { return (r && (FLAG || (FLAG & f))); }])],
-@@ -431,7 +431,7 @@ AM_CONDITIONAL(SANE_LOGICAL_OP_WARNING,
+@@ -480,7 +480,7 @@ AM_CONDITIONAL(SANE_LOGICAL_OP_WARNING,
  # -Wduplicated-cond was added by GCC6
  AC_CACHE_CHECK([whether gcc accepts -Wduplicated-cond], ac_cv_duplicated_cond, [dnl
  old_CFLAGS="$CFLAGS"
@@ -85,7 +85,7 @@ index 1cf6245..6f0aaf0 100644
  AC_COMPILE_IFELSE([AC_LANG_SOURCE([])],
  		  ac_cv_duplicated_cond=yes, ac_cv_duplicated_cond=no)
  CFLAGS="$old_CFLAGS"])
-@@ -441,7 +441,7 @@ AM_CONDITIONAL(HAVE_DUPLICATED_COND_WARNING,
+@@ -490,7 +490,7 @@ AM_CONDITIONAL(HAVE_DUPLICATED_COND_WARNING,
  # -Wnull-dereference was added by GCC6
  AC_CACHE_CHECK([whether gcc accepts -Wnull-dereference], ac_cv_null_dereference, [dnl
  old_CFLAGS="$CFLAGS"
@@ -94,7 +94,7 @@ index 1cf6245..6f0aaf0 100644
  AC_COMPILE_IFELSE([AC_LANG_SOURCE([])],
  		  ac_cv_null_dereference=yes, ac_cv_null_dereference=no)
  CFLAGS="$old_CFLAGS"])
-@@ -451,7 +451,7 @@ AM_CONDITIONAL(HAVE_NULL_DEREFERENCE_WARNING,
+@@ -500,7 +500,7 @@ AM_CONDITIONAL(HAVE_NULL_DEREFERENCE_WARNING,
  # -Wimplicit-fallthrough was added by GCC7
  AC_CACHE_CHECK([whether gcc accepts -Wimplicit-fallthrough], ac_cv_implicit_fallthrough, [dnl
  old_CFLAGS="$CFLAGS"
@@ -103,120 +103,3 @@ index 1cf6245..6f0aaf0 100644
  AC_COMPILE_IFELSE([AC_LANG_SOURCE([])],
  		  ac_cv_implicit_fallthrough=yes, ac_cv_implicit_fallthrough=no)
  CFLAGS="$old_CFLAGS"])
-diff --git a/lib/Makefile.in b/lib/Makefile.in
-index 3e7d403..2a255e5 100644
---- a/lib/Makefile.in
-+++ b/lib/Makefile.in
-@@ -331,7 +331,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
- 	-Wold-style-definition -Wstrict-prototypes \
- 	$(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
- 	$(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
--	$(if $($(*F)_no_Werror),,-Werror) $(if \
-+	$(if $($(*F)_no_Werror),,) $(if \
- 	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
- 	$($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) $(if \
- 	$($(*F)_no_Wpacked_not_aligned),-Wno-packed-not-aligned,) \
-diff --git a/libasm/Makefile.in b/libasm/Makefile.in
-index 844b0c4..e8b2f7a 100644
---- a/libasm/Makefile.in
-+++ b/libasm/Makefile.in
-@@ -384,7 +384,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
- 	    -Wold-style-definition -Wstrict-prototypes \
- 	    $(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
- 	    $(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
--	    $(if $($(*F)_no_Werror),,-Werror) \
-+	    $(if $($(*F)_no_Werror),,) \
- 	    $(if $($(*F)_no_Wunused),,-Wunused -Wextra) \
- 	    $(if $($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) \
- 	    $(if $($(*F)_no_Wpacked_not_aligned),-Wno-packed-not-aligned,) \
-diff --git a/libcpu/Makefile.in b/libcpu/Makefile.in
-index e9e723b..dbe8f4a 100644
---- a/libcpu/Makefile.in
-+++ b/libcpu/Makefile.in
-@@ -366,7 +366,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
- 	-Wold-style-definition -Wstrict-prototypes \
- 	$(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
- 	$(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
--	$(if $($(*F)_no_Werror),,-Werror) $(if \
-+	$(if $($(*F)_no_Werror),,) $(if \
- 	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
- 	$($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) $(if \
- 	$($(*F)_no_Wpacked_not_aligned),-Wno-packed-not-aligned,) \
-diff --git a/libdw/Makefile.in b/libdw/Makefile.in
-index 2f193f8..74d5f28 100644
---- a/libdw/Makefile.in
-+++ b/libdw/Makefile.in
-@@ -436,7 +436,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
- 	-Wold-style-definition -Wstrict-prototypes \
- 	$(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
- 	$(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
--	$(if $($(*F)_no_Werror),,-Werror) $(if \
-+	$(if $($(*F)_no_Werror),,) $(if \
- 	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
- 	$($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) $(if \
- 	$($(*F)_no_Wpacked_not_aligned),-Wno-packed-not-aligned,) \
-diff --git a/libdwelf/Makefile.in b/libdwelf/Makefile.in
-index 0e32ab1..a6de361 100644
---- a/libdwelf/Makefile.in
-+++ b/libdwelf/Makefile.in
-@@ -364,7 +364,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
- 	    -Wold-style-definition -Wstrict-prototypes \
- 	    $(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
- 	    $(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
--	    $(if $($(*F)_no_Werror),,-Werror) \
-+	    $(if $($(*F)_no_Werror),,) \
- 	    $(if $($(*F)_no_Wunused),,-Wunused -Wextra) \
- 	    $(if $($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) \
- 	    $(if $($(*F)_no_Wpacked_not_aligned),-Wno-packed-not-aligned,) \
-diff --git a/libdwfl/Makefile.in b/libdwfl/Makefile.in
-index b8e28d5..4f51bbf 100644
---- a/libdwfl/Makefile.in
-+++ b/libdwfl/Makefile.in
-@@ -420,7 +420,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
- 	    -Wold-style-definition -Wstrict-prototypes \
- 	    $(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
- 	    $(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
--	    $(if $($(*F)_no_Werror),,-Werror) \
-+	    $(if $($(*F)_no_Werror),,) \
- 	    $(if $($(*F)_no_Wunused),,-Wunused -Wextra) \
- 	    $(if $($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) \
- 	    $(if $($(*F)_no_Wpacked_not_aligned),-Wno-packed-not-aligned,) \
-diff --git a/libebl/Makefile.in b/libebl/Makefile.in
-index 13a6f81..562faa1 100644
---- a/libebl/Makefile.in
-+++ b/libebl/Makefile.in
-@@ -384,7 +384,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
- 	-Wold-style-definition -Wstrict-prototypes \
- 	$(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
- 	$(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
--	$(if $($(*F)_no_Werror),,-Werror) $(if \
-+	$(if $($(*F)_no_Werror),,) $(if \
- 	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
- 	$($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) $(if \
- 	$($(*F)_no_Wpacked_not_aligned),-Wno-packed-not-aligned,) \
-diff --git a/libelf/Makefile.in b/libelf/Makefile.in
-index 602e66d..360927e 100644
---- a/libelf/Makefile.in
-+++ b/libelf/Makefile.in
-@@ -427,7 +427,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
- 	-Wold-style-definition -Wstrict-prototypes \
- 	$(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
- 	$(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
--	$(if $($(*F)_no_Werror),,-Werror) $(if \
-+	$(if $($(*F)_no_Werror),,) $(if \
- 	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
- 	$($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) $(if \
- 	$($(*F)_no_Wpacked_not_aligned),-Wno-packed-not-aligned,) \
-diff --git a/src/Makefile.in b/src/Makefile.in
-index 82d6835..b8bd7f4 100644
---- a/src/Makefile.in
-+++ b/src/Makefile.in
-@@ -441,7 +441,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
- 	    -Wold-style-definition -Wstrict-prototypes \
- 	    $(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
- 	    $(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
--	    $(if $($(*F)_no_Werror),,-Werror) \
-+	    $(if $($(*F)_no_Werror),,) \
- 	    $(if $($(*F)_no_Wunused),,-Wunused -Wextra) \
- 	    $(if $($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) \
- 	    $(if $($(*F)_no_Wpacked_not_aligned),-Wno-packed-not-aligned,) \

--- a/recipes/elfutils/all/test_package/test_package.c
+++ b/recipes/elfutils/all/test_package/test_package.c
@@ -1,9 +1,10 @@
-#include <dwarf.h>
+#include <gelf.h>
 #include <elfutils/libasm.h>
 #include <elfutils/libdwelf.h>
 #include <elfutils/libdwfl.h>
 #include <elfutils/libdw.h>
-#include <elfutils/libebl.h>
+//#include <elfutils/libebl.h>
+#include <dwarf.h>
 #include <libelf.h>
 
 #include <stdio.h>


### PR DESCRIPTION
Update to 0.180
Apparently, upstream got rid of loadable modules.

Porting your patches to 0.180 was straightforward, but the actual `autoreconf` fails because the `automake` support of conan is incomplete.

the `configure.ac` script uses PKG_CONFIG scripts which should be provided by a pkg-config package.
https://github.com/conan-io/conan-center-index/pull/1013 will provide this

But then, automake needs to be able to find these external files, which https://github.com/conan-io/conan-center-index/pull/2038 should provide.

So what I propose to do:
- fiddle a bit with my changes, and commit them to cci
- see if the ci can build them, if so: cool
- wait until the pkg-config and automake recipes are merged, then remove my `tools.replace_in_file` and uncomment the patches + `autoreconf`

